### PR TITLE
Dump deployment info to a YAML file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    beanstalkify (0.0.2)
+    beanstalkify (0.0.3)
       aws-sdk
 
 GEM

--- a/bin/beanstalkify
+++ b/bin/beanstalkify
@@ -1,8 +1,7 @@
 #!/usr/bin/env ruby
 require 'optparse'
 require 'yaml'
-require 'beanstalkify/beanstalk'
-require 'beanstalkify/application'
+Dir.glob(File.join(File.dirname(__FILE__), "../lib/beanstalkify", "*.rb")).each { |f| require f }
 
 options = {}
 OptionParser.new do |opts|
@@ -18,18 +17,27 @@ OptionParser.new do |opts|
     opts.on("-s", "--stack [stack]", "Stack to provision (e.g. '64bit Amazon Linux running Node.js')") do |v|
         options[:stack] = v
     end
-    opts.on("-c", "--config [file]", "Configuration overrides for the environment") do |v|
+    opts.on("-c", "--config [file]", "Configuration overrides for the environment (optional)") do |v|
         options[:config] = YAML.load_file(v)
     end
+    opts.on("-o", "--outfile [file]", "File to write YAML environment details for future scripting (optional)") do |v|
+        options[:outfile] = v
+    end    
 end.parse!
 
 required_params = [:credentials, :archive, :environment, :stack]
 unless (required_params - options.keys).empty?
-    puts "Example usage: beanstalkify -k credentials.yml -a AppName-version.zip -e AppName-test -s '64bit Amazon Linux running Node.js' -c config.yml"
+    puts "Example usage: beanstalkify -k credentials.yml -a AppName-version.zip -e AppName-test -s '64bit Amazon Linux running Node.js' [-c config.yml] [-o info.yml]"
     exit
 end
 
 Beanstalkify::Beanstalk.configure! options[:credentials]
+
 app = Beanstalkify::Application.new(options[:stack], options[:config] || [])
-app.deploy!(options[:archive], options[:environment])
+deployment = Beanstalkify::Deploy.new(options[:archive])
+environment = Beanstalkify::Environment.new(options[:environment])
+
+deployment_info = app.deploy! deployment, environment
+
+File.open(options[:outfile], 'w') { |f| f.puts deployment_info.to_yaml } if options[:outfile]
 

--- a/lib/beanstalkify/application.rb
+++ b/lib/beanstalkify/application.rb
@@ -1,6 +1,3 @@
-require 'beanstalkify/environment'
-require 'beanstalkify/deploy'
-
 module Beanstalkify
     class Application
         attr_accessor :stack, :config
@@ -14,25 +11,24 @@ module Beanstalkify
 
         # Deploy an archive to an environment. 
         # If the environment doesn't exist, it will be created.
-        def deploy!(archive, environment_name)
-            deployment = Deploy.new(archive)
-            env = Environment.new(environment_name)
+        def deploy!(deployment, env)
             if deployment.deployed?
-                puts "#{deployment.application.version} is already uploaded."
+                puts "#{deployment.archive.version} is already uploaded."
             else
                 deployment.upload!
                 deployment.wait!
             end
             if env.status.empty?
-                puts "Creating stack '#{@stack}' for #{deployment.application.name}-#{deployment.application.version}..."
-                env.create!(deployment.application, @stack, @config)
+                puts "Creating stack '#{@stack}' for #{deployment.archive.name}-#{deployment.archive.version}..."
+                env.create!(deployment.archive, @stack, @config)
                 env.wait!("Launching")
             else
-                puts "Deploying #{deployment.application.version} to #{environment_name}..."
-                env.deploy!(deployment.application, @config)
+                puts "Deploying #{deployment.archive.version} to #{env.name}..."
+                env.deploy!(deployment.archive, @config)
                 env.wait!("Updating")
             end
             puts "Done. Visit http://#{env.url} in your browser."
+            DeploymentInfo.new env, deployment.archive
         end
     end
 end

--- a/lib/beanstalkify/deploy.rb
+++ b/lib/beanstalkify/deploy.rb
@@ -4,10 +4,10 @@ require 'aws-sdk'
 
 module Beanstalkify
     class Deploy
-        attr_accessor :beanstalk, :application
+        attr_accessor :beanstalk, :archive
 
         def initialize(path)
-            @application = Archive.new(path)
+            @archive = Archive.new(path)
             @beanstalk = Beanstalk.api
         end
 
@@ -18,15 +18,15 @@ module Beanstalkify
         def upload!
             client = AWS::S3.new.client
             bucket = self.bucket
-            puts "Uploading #{@application.filename} to bucket #{bucket}..."
-            client.put_object({ :bucket_name => bucket, :key => @application.filename, :data => File.open(@application.path) })
-            puts "Creating #{@application.name} - #{@application.version} in beanstalk"
+            puts "Uploading #{@archive.filename} to bucket #{bucket}..."
+            client.put_object({ :bucket_name => bucket, :key => @archive.filename, :data => File.open(@archive.path) })
+            puts "Creating #{@archive.name} - #{@archive.version} in beanstalk"
             @beanstalk.create_application_version({ 
-                :application_name => @application.name, 
-                :version_label => @application.version,
+                :application_name => @archive.name, 
+                :version_label => @archive.version,
                 :source_bundle => {
                     :s3_bucket => bucket,
-                    :s3_key => @application.filename
+                    :s3_key => @archive.filename
                 },
                 :auto_create_application => true
             })
@@ -34,14 +34,14 @@ module Beanstalkify
 
         def deployed?
             @beanstalk.describe_application_versions({
-                :application_name => @application.name,
-                :version_labels => [@application.version]
+                :application_name => @archive.name,
+                :version_labels => [@archive.version]
             }).data[:application_versions].count > 0
         end
 
         def wait!
             while not self.deployed?
-                puts "Waiting for #{@application.version} to be available..."
+                puts "Waiting for #{@archive.version} to be available..."
                 sleep 10
             end
         end

--- a/lib/beanstalkify/deployment_info.rb
+++ b/lib/beanstalkify/deployment_info.rb
@@ -1,0 +1,16 @@
+module Beanstalkify
+  class DeploymentInfo
+    def initialize(environment, archive)
+      @environment, @archive = environment, archive
+    end
+    
+    def to_yaml
+      {
+        'app_name'    => @archive.name,
+        'app_version' => @archive.version,
+        'env_name'    => @environment.name,
+        'env_url'     => @environment.url
+      }.to_yaml
+    end
+  end
+end

--- a/lib/beanstalkify/version.rb
+++ b/lib/beanstalkify/version.rb
@@ -1,3 +1,3 @@
 module Beanstalkify
-  VERSION = "0.0.2"  
+  VERSION = "0.0.3"
 end

--- a/test/deployment_info_spec.rb
+++ b/test/deployment_info_spec.rb
@@ -1,0 +1,21 @@
+require './lib/beanstalkify/deployment_info'
+require './lib/beanstalkify/archive'
+
+describe Beanstalkify::DeploymentInfo do
+  before(:each) do
+    environment = double(name: 'TestEnv', url: 'http://env.url')
+    archive = Beanstalkify::Archive.new('test-website-1.0.1.zip')
+    @info = Beanstalkify::DeploymentInfo.new(environment, archive)
+  end
+  
+  it 'dumps useful info to a YAML string' do
+    expected = {
+      'app_name'    => 'test-website',
+      'app_version' => '1.0.1',
+      'env_name'    => 'TestEnv',
+      'env_url'     => 'http://env.url'
+    }
+    @info.to_yaml.should == expected.to_yaml
+  end
+end
+


### PR DESCRIPTION
Passing an optional -o outfile.yml argument will dump useful info (including the generated URL) to a YAML file.

This will be valuable for scripting - for example it may be promoted as an artefact in a build pipeline and the values extracted to allow automated tests or monitoring to be run against the new environment.

This PR also increases the version number to 0.0.3.
