### PR TITLE
Fail if environment is not healthy.

### DIFF
--- a/bin/beanstalkify
+++ b/bin/beanstalkify
@@ -44,3 +44,4 @@ deployment_info = app.deploy! archive, environment
 
 File.open(options[:outfile], 'w') { |f| f.puts deployment_info.to_yaml } if options[:outfile]
 
+raise("Deployed environment is not healthy") unless environment.healthy?

--- a/lib/beanstalkify/environment.rb
+++ b/lib/beanstalkify/environment.rb
@@ -33,20 +33,18 @@ module Beanstalkify
         end
 
         def status
-            envs = @beanstalk.describe_environments({
-                :environment_names => [self.name],
-                :include_deleted => false
-            }).data[:environments]
-            e = envs.first
+            e = describe_environment
             e ? e[:status] : ""
         end
 
         def url
-            envs = @beanstalk.describe_environments({
-                :environment_names => [self.name]
-            }).data[:environments]
-            e = envs.first
+            e = describe_environment
             e ? e[:endpoint_url] : ""
+        end
+        
+        def healthy?
+           e = describe_environment
+           e ? e[:health] == 'Green' : false
         end
 
         # Wait for the status to change from `old_status` to something else
@@ -57,6 +55,15 @@ module Beanstalkify
                 sleep 5
             end
             puts
+        end
+        
+        private
+        
+        def describe_environment
+            @beanstalk.describe_environments({
+                :environment_names => [name],
+                :include_deleted => false
+            }).data[:environments].first
         end
     end
 end

--- a/lib/beanstalkify/environment.rb
+++ b/lib/beanstalkify/environment.rb
@@ -39,7 +39,7 @@ module Beanstalkify
 
         def url
             e = describe_environment
-            e ? e[:endpoint_url] : ""
+            e ? e[:cname] : ""
         end
         
         def healthy?

--- a/test/environment_spec.rb
+++ b/test/environment_spec.rb
@@ -17,9 +17,9 @@ describe Beanstalkify::Environment do
     @env.status.should == 'Uncertain'
   end
   
-  it 'exposes the Beanstalk ELB URL' do
-    when_beanstalk_describe_environments_returns(endpoint_url: 'http://elb.longurl.com')
-    @env.url.should == 'http://elb.longurl.com'
+  it 'exposes the Beanstalk CNAME URL' do
+    when_beanstalk_describe_environments_returns(cname: 'http://cname.elasticbeanstalk.com')
+    @env.url.should == 'http://cname.elasticbeanstalk.com'
   end
   
   it 'is healthy when Beanstalk reports that it is green' do

--- a/test/environment_spec.rb
+++ b/test/environment_spec.rb
@@ -3,11 +3,38 @@ require './lib/beanstalkify/environment'
 
 describe Beanstalkify::Environment do
   before do
+    allow(Beanstalkify::Beanstalk).to receive(:api).and_return @beanstalk_api = double
     archive = Beanstalkify::Archive.new '/path/to/my/archive/app-name-version.zip'
     @env = Beanstalkify::Environment.new archive, "Test"
   end
 
   it 'prepends the application name because environment names must be unique within an AWS account' do
     @env.name.should == "app-name-Test"
+  end
+  
+  it 'exposes the Beanstalk status' do
+    when_beanstalk_describe_environments_returns(status: 'Uncertain')
+    @env.status.should == 'Uncertain'
+  end
+  
+  it 'exposes the Beanstalk ELB URL' do
+    when_beanstalk_describe_environments_returns(endpoint_url: 'http://elb.longurl.com')
+    @env.url.should == 'http://elb.longurl.com'
+  end
+  
+  it 'is healthy when Beanstalk reports that it is green' do
+    when_beanstalk_describe_environments_returns(health: 'Red')
+    @env.should_not be_healthy
+    when_beanstalk_describe_environments_returns(health: 'Green')
+    @env.should be_healthy
+  end
+  
+  def when_beanstalk_describe_environments_returns(env_data)
+    expect(@beanstalk_api).to receive(:describe_environments).with(
+      environment_names: ["app-name-Test"],
+      include_deleted: false
+    ).and_return double(
+      data: {environments: [env_data]}
+    )
   end
 end


### PR DESCRIPTION
Environment#healthy? checks that the Beanstalk status is green.
This is used in the beanstalkify script to raise an error rather than cheerfully exitcode 0'ing when the new environment has really failed to launch.
