### PR TITLE
Wait for up to 2 minutes for new env to turn healthy

### DIFF
--- a/lib/beanstalkify/application.rb
+++ b/lib/beanstalkify/application.rb
@@ -24,6 +24,8 @@ module Beanstalkify
                 env.deploy!(archive, @config)
                 env.wait_until_status_is_not "Updating"
             end
+            
+            env.wait_until_healthy
             puts "Done. Visit http://#{env.url} in your browser."
             DeploymentInfo.new env, archive
         end

--- a/lib/beanstalkify/application.rb
+++ b/lib/beanstalkify/application.rb
@@ -18,11 +18,11 @@ module Beanstalkify
             if env.status.empty?
                 puts "Creating stack '#{@stack}' for #{archive.app_name}-#{archive.version}..."
                 env.create!(archive, @stack, @cnames, @config)
-                env.wait!("Launching")
+                env.wait_until_status_is_not "Launching"
             else
                 puts "Deploying #{archive.version} to #{env.name}..."
                 env.deploy!(archive, @config)
-                env.wait!("Updating")
+                env.wait_until_status_is_not "Updating"
             end
             puts "Done. Visit http://#{env.url} in your browser."
             DeploymentInfo.new env, archive

--- a/lib/beanstalkify/environment.rb
+++ b/lib/beanstalkify/environment.rb
@@ -64,7 +64,7 @@ module Beanstalkify
         end
 
         # Wait for the status to change from `old_status` to something else
-        def wait!(old_status)
+        def wait_until_status_is_not(old_status)
             puts "Waiting for #{self.name} to finish #{old_status.downcase}..."
             while self.status == old_status
                 print '.'              

--- a/lib/beanstalkify/environment.rb
+++ b/lib/beanstalkify/environment.rb
@@ -1,85 +1,85 @@
 require 'beanstalkify/beanstalk'
 
 module Beanstalkify
-    class Environment
-        attr_accessor :name
+  class Environment
+      attr_accessor :name
 
-        def initialize(archive, name)
-            @name = [archive.app_name, name].join("-")
-            @beanstalk = Beanstalk.api
-        end
-
-        # Assuming the provided app has already been uploaded,
-        # update this environment to the app's version
-        # Optionally pass in a bunch of settings to override
-        def deploy!(app, settings=[])
-            @beanstalk.update_environment({
-                :version_label => app.version,
-                :environment_name => self.name,
-                :option_settings => settings
-            })
-        end
-
-        # Assuming the archive has already been uploaded, 
-        # create a new environment with the app deployed onto the provided stack.
-        # Attempts to use the first available cname in the cnames array.
-        def create!(archive, stack, cnames, settings=[])
-            params = {
-                :application_name => archive.app_name,
-                :version_label => archive.version,
-                :environment_name => self.name,
-                :solution_stack_name => stack,
-                :option_settings => settings
-            }
-            cnames.each do |c|
-                if dns_available(c)
-                    params[:cname_prefix] = c
-                    break
-                else
-                    puts "CNAME #{c} is unavailable."
-                end
-            end
-            @beanstalk.create_environment(params)
-        end
-
-        def dns_available(cname)
-            @beanstalk.check_dns_availability({
-                :cname_prefix => cname
-            })[:available]
-        end
-
-        def status
-            e = describe_environment
-            e ? e[:status] : ""
-        end
-
-        def url
-            e = describe_environment
-            e ? e[:cname] : ""
-        end
-        
-        def healthy?
-           e = describe_environment
-           e ? e[:health] == 'Green' : false
-        end
-
-        # Wait for the status to change from `old_status` to something else
-        def wait_until_status_is_not(old_status)
-            puts "Waiting for #{self.name} to finish #{old_status.downcase}..."
-            while self.status == old_status
-                print '.'              
-                sleep 5
-            end
-            puts
-        end
-        
-        private
-        
-        def describe_environment
-            @beanstalk.describe_environments({
-                :environment_names => [name],
-                :include_deleted => false
-            }).data[:environments].first
-        end
+    def initialize(archive, name)
+      @name = [archive.app_name, name].join("-")
+      @beanstalk = Beanstalk.api
     end
+
+    # Assuming the provided app has already been uploaded,
+    # update this environment to the app's version
+    # Optionally pass in a bunch of settings to override
+    def deploy!(app, settings=[])
+      @beanstalk.update_environment({
+        version_label: app.version,
+        environment_name: self.name,
+        option_settings: settings
+      })
+    end
+
+    # Assuming the archive has already been uploaded, 
+    # create a new environment with the app deployed onto the provided stack.
+    # Attempts to use the first available cname in the cnames array.
+    def create!(archive, stack, cnames, settings=[])
+      params = {
+        application_name: archive.app_name,
+        version_label: archive.version,
+        environment_name: self.name,
+        solution_stack_name: stack,
+        option_settings: settings
+      }
+      cnames.each do |c|
+        if dns_available(c)
+          params[:cname_prefix] = c
+          break
+        else
+          puts "CNAME #{c} is unavailable."
+        end
+      end
+      @beanstalk.create_environment(params)
+    end
+
+    def dns_available(cname)
+      @beanstalk.check_dns_availability({
+        cname_prefix: cname
+      })[:available]
+    end
+
+    def url
+      e = describe_environment
+      e ? e[:cname] : ""
+    end
+  
+    def healthy?
+      e = describe_environment
+      e ? e[:health] == 'Green' : false
+    end
+  
+    def status
+      e = describe_environment
+      e ? e[:status] : ""
+    end
+
+    # Wait for the status to change from `old_status` to something else
+    def wait_until_status_is_not(old_status)
+      puts "Waiting for #{self.name} to finish #{old_status.downcase}..."
+      while self.status == old_status
+        print '.'              
+        sleep 5
+      end
+      puts
+    end
+  
+    private
+  
+    def describe_environment
+      @beanstalk.describe_environments({
+        environment_names: [name],
+        include_deleted: false
+      }).data[:environments].first
+    end
+  end
 end


### PR DESCRIPTION
Beanstalk's default healthcheck runs every 30 seconds and requires 3 successive greens to be flagged as healthy.
We've been seeing cases where the environment comes up in a Red state (does the healthcheck start running too soon?) and flicking over to green shortly after deployment.

This change makes Beanstalkify treat these cases as successes.
